### PR TITLE
Fix links for Jenkins and GitHub issues.

### DIFF
--- a/AutomatedReview/RootCauseRunbook.md
+++ b/AutomatedReview/RootCauseRunbook.md
@@ -2,17 +2,16 @@
 
 ### Overview
 
-When a failure occurs in the Open 3d Engine (O3DE) main branch Automated Review (AR) pipeline, a manual investigation must occur in order to identify and assign issues to the correct owners. This runbook will go over steps for Root Cause Analysis (RCA) for failures in the AR pipeline.
+When a failure occurs in the Open 3d Engine (O3DE) Automated Review (AR) pipeline, a manual investigation must occur in order to identify and assign issues to the correct owners. This runbook will go over steps for Root Cause Analysis (RCA) for failures in the AR pipeline.
 
 ### Links
 
-* [Jenkins main branch updates](https://jenkins-o3de.agscollab.com/blue/organizations/jenkins/O3DE/activity/?branch=main)
-* [Jenkins nightly updates](https://jenkins-pipeline.agscollab.com/job/O3DE-LY-Fork_nightly/)
-* [GitHub Issues template](https://github.com/aws-lumberyard/o3de/issues/new?assignees=&labels=&template=ar_bug_report-md.md&title=)
+* [Jenkins branch updates](https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE/branches/)
+* [GitHub Issues template](https://github.com/o3de/o3de/issues/new?assignees=&labels=&template=ar_bug_report-md.md&title=)
 
 ### RCA Steps
 
-1. **Go to the [Jenkins main branch update page](https://jenkins-o3de.agscollab.com/blue/organizations/jenkins/O3DE/activity/?branch=main). Locate and click the failing job.**
+1. **Go to the [Jenkins branch update page](https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE/branches/). Locate the branch and click the failing job.**
 ![Jenkins page](./images/rca_1.png)
 1. **At the top of the page, you will see the pipeline steps. Click on any failing step to view its logs.**
 ![Failing jobs](./images/rca_2.png)


### PR DESCRIPTION
Also updating branch update link. Main is no longer the default branch for PRs. Development or stabalization should be targeted based on the change.

Nightly pipeline is only running on the jenkins-pipeline instance which is not accessible publicly. Link will be re-added once it's enabled in jenkins.build.o3de.org.

Signed-off-by: brianherrera <briher@amazon.com>