### PR TITLE
Create roadmap-item issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -2,7 +2,7 @@
 name: 'Roadmap Item'
 about: Create roadmap item for this project
 title: Roadmap Item =description=
-labels: kind/roadmap
+labels: kind/roadmap, needs-triage
 assignees: ''
 
 ---
@@ -26,6 +26,8 @@ Single paragraph explanation of the roadmap item
 
 ### Tasks
 What tasks are necessary to complete the roadmap item?
+- [ ] _GitHub issue 1 link_
+- [ ] _GitHub issue 2 link and so on._
 
 ### Related Links
 Link to additional informaton such as RFC related to the roadmap item.

--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -1,0 +1,31 @@
+---
+name: 'Roadmap Item'
+about: Create roadmap item for this project
+title: Roadmap Item =description=
+labels: kind/roadmap
+assignees: ''
+
+---
+
+# O3DE Roadmap Item Template
+
+### When using this template, you do not have to fill out every question below. The questions are there for guidance.
+
+This roadmap item template should be used for any feature that shows in the O3DE public roadmap. The issue communicates the initiative and vision of the SIG.
+
+# ----- DELETE EVERYTHING FROM THE TOP TO THE SUMMARY LINE BELOW WHEN USING TEMPLATE ----- #
+
+### Summary:
+Single paragraph explanation of the roadmap item
+
+### What is the relevance of this feature?
+- What problems does it solves? 
+- Why is this important? 
+- What will it do once completed?
+- Are there any changes or impacts to other features? 
+
+### Tasks
+What tasks are necessary to complete the roadmap item?
+
+### Related Links
+Link to additional informaton such as RFC related to the roadmap item.


### PR DESCRIPTION
# Description
The context of the roadmap item can be read here: https://github.com/o3de/sig-release/issues/79.

# Action Needed
Since the RFC leverage three labels, kind/roadmap, needs-triage, and triage/accepted, please create this label in your SIG repo if it does not exist already once you merge the PR.

### needs-triage
Taken from [O3DE label](https://github.com/o3de/o3de/labels?q=needs-triage)
- label name: needs-triage
- description: Indicates an issue or PR lacks a triage/foo label and requires one

### triage/accepted
Taken from [O3DE Label](https://github.com/o3de/o3de/labels?q=triage%2Faccepted)
- label name: triage/accepted
- description: Indicates an issue or PR is ready to be actively worked on.

### kind/roadmap
Taken from [O3DE Label](https://github.com/o3de/o3de/labels?q=kind%2Froadmap)
- label name: **kind/roadmap**
- description: **Categorizes an issue that goes in the O3DE Public Roadmap**

Signed-off-by: Vincent <vincentbiasa6767@gmail.com>